### PR TITLE
mblock 4 fix

### DIFF
--- a/assets/gridblock_mblock.js
+++ b/assets/gridblock_mblock.js
@@ -1,0 +1,254 @@
+/**
+ * Gridblock MBlock Integration
+ * Funktionen für die Kompatibilität mit MBlock Addon
+ */
+
+// Global verfügbare MBlock-Funktionen für Gridblock
+window.GridblockMBlock = {
+    
+    /**
+     * Initialisiert MBlock-Wrapper nach dem Einfügen von Content
+     * @param {jQuery} content - Der eingefügte Content
+     */
+    initializeMBlocks: function(content) {
+        this.processMBlocksRecursive(content);
+    },
+    
+    /**
+     * Verarbeitet MBlocks rekursiv im gegebenen Content
+     * @param {jQuery} content - Der zu verarbeitende Content
+     */
+    processMBlocksRecursive: function(content) {
+        var mblockWrappers = content.find('.mblock-wrapper');
+        
+        if (mblockWrappers.length > 0) {
+            var self = this;
+            mblockWrappers.each(function() {
+                var mblockWrapper = $(this);
+                
+                setTimeout(function() {
+                    // Bestehende MBlock Items entfernen (werden durch Paste neu erstellt)
+                    mblockWrapper.find('.mblock-item').remove();
+                    
+                    // MBlock neu initialisieren
+                    self.reinitializeMBlock(mblockWrapper);
+                    
+                    // Prüfe ob noch weitere MBlocks existieren
+                    setTimeout(function() {
+                        self.processMBlocksRecursive(content);
+                    }, 200);
+                    
+                }, 300);
+            });
+        }
+    },
+    
+    /**
+     * Initialisiert einen MBlock-Wrapper neu
+     * @param {jQuery} mblockWrapper - Der MBlock-Wrapper
+     */
+    reinitializeMBlock: function(mblockWrapper) {
+        // MBlock neu initialisieren
+        if (typeof window.mblock_init === 'function') {
+            window.mblock_init(mblockWrapper);
+        }
+        
+        // MBlock Items neu indizieren
+        if (typeof window.mblock_reindex === 'function') {
+            window.mblock_reindex(mblockWrapper);
+        }
+        
+        // Events neu binden
+        if (typeof window.mblock_add === 'function') {
+            window.mblock_add(mblockWrapper);
+        }
+        if (typeof window.mblock_sortable === 'function') {
+            window.mblock_sortable(mblockWrapper);
+        }
+        if (typeof window.mblock_remove === 'function') {
+            window.mblock_remove(mblockWrapper);
+        }
+        if (typeof window.mblock_init_toolbar === 'function') {
+            window.mblock_init_toolbar(mblockWrapper);
+        }
+        
+        // Custom Event für MBlock triggern
+        mblockWrapper.trigger('mblock:refresh');
+        mblockWrapper.trigger('mblock:init');
+    },
+    
+    /**
+     * Sammelt Formulardaten aus einem Container für MBlock-Unterstützung
+     * @param {jQuery} container - Container mit Formularelementen
+     * @param {string} sourceUid - Quell-UID für Mapping
+     * @returns {Object} Gesammelte Formulardaten
+     */
+    collectFormData: function(container, sourceUid) {
+        var formData = {};
+        
+        // Alle Formularelemente sammeln
+        container.find('input, textarea, select').each(function() {
+            var element = $(this);
+            var name = element.attr('name');
+            var id = element.attr('id');
+            var type = element.attr('type');
+            var value = '';
+            
+            if (name && name.trim() !== '') {
+                // Wert je nach Elementtyp ermitteln
+                if (type === 'checkbox' || type === 'radio') {
+                    if (element.is(':checked')) {
+                        value = element.val();
+                    }
+                } else if (element.is('select')) {
+                    value = element.val();
+                } else {
+                    value = element.val();
+                }
+                
+                formData[name] = {
+                    value: value,
+                    type: type,
+                    id: id,
+                    checked: element.is(':checked'),
+                    selected: element.is(':selected')
+                };
+            }
+        });
+        
+        return formData;
+    },
+    
+    /**
+     * Stellt Formulardaten in einem Container wieder her
+     * @param {jQuery} container - Ziel-Container
+     * @param {Object} formData - Wiederherzustellende Formulardaten
+     * @param {string} sourceUid - Quell-UID
+     * @param {string} targetUid - Ziel-UID
+     */
+    restoreFormData: function(container, formData, sourceUid, targetUid) {
+        var self = this;
+        
+        Object.keys(formData).forEach(function(originalName) {
+            var data = formData[originalName];
+            
+            // UID in Feldnamen ersetzen
+            var newName = self.replaceUidInString(originalName, sourceUid, targetUid);
+            var element = container.find('[name="' + newName + '"]');
+            
+            if (element.length > 0) {
+                var type = data.type;
+                
+                if (type === 'checkbox' || type === 'radio') {
+                    element.prop('checked', data.checked);
+                } else if (element.is('select')) {
+                    element.val(data.value);
+                } else {
+                    element.val(data.value);
+                }
+                
+                // Event triggern für eventuelle Listener
+                element.trigger('change');
+            }
+        });
+    },
+    
+    /**
+     * Ersetzt UID-Patterns in einem String
+     * @param {string} str - Zu bearbeitender String
+     * @param {string} sourceUid - Quell-UID
+     * @param {string} targetUid - Ziel-UID
+     * @returns {string} Bearbeiteter String
+     */
+    replaceUidInString: function(str, sourceUid, targetUid) {
+        if (!str || !sourceUid || !targetUid) return str;
+        
+        // Verschiedene UID-Patterns ersetzen
+        var patterns = [
+            new RegExp('\\b' + sourceUid + '\\b', 'g'),
+            new RegExp('GBS[0-9a-f]{32}', 'g'),
+            new RegExp('gbs[0-9a-f]{32}', 'g'),
+            new RegExp(sourceUid.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')
+        ];
+        
+        var result = str;
+        patterns.forEach(function(pattern) {
+            result = result.replace(pattern, targetUid);
+        });
+        
+        return result;
+    },
+
+    /**
+     * Verarbeitet MBlock-Daten beim Kopieren/Einfügen
+     * @param {jQuery} dst - Ziel-Container
+     * @param {Object} parsedData - Geparste Formulardaten
+     * @param {string} sourceUID - Quell-UID
+     * @param {string} uID - Ziel-UID
+     */
+    processMBlockData: function(dst, parsedData, sourceUID, uID) {
+        var self = this;
+        var mblockWrappers = dst.find('.mblock_wrapper');
+        
+        mblockWrappers.each(function() {
+            var mblockWrapper = $(this);
+            
+            // Analysiere die kopierten Daten um zu sehen wie viele MBlock-Items benötigt werden
+            var maxMblockIndex = -1;
+            $.each(parsedData, function(fieldName, fieldValue) {
+                var mblockMatch = fieldName.match(/\[(\d+)_MBLOCK\]\[(\d+)\]/);
+                if (mblockMatch) {
+                    var itemIndex = parseInt(mblockMatch[2]);
+                    maxMblockIndex = Math.max(maxMblockIndex, itemIndex);
+                }
+            });
+            
+            // Falls MBlock-Items gefunden wurden, erstelle die notwendigen Items
+            if (maxMblockIndex >= 0) {
+                var currentItems = mblockWrapper.find('.sortitem').length;
+                var neededItems = maxMblockIndex + 1;
+                
+                // Füge fehlende MBlock-Items hinzu
+                for (var i = currentItems; i < neededItems; i++) {
+                    var addButton = mblockWrapper.find('.addme').first();
+                    if (addButton.length > 0) {
+                        addButton.trigger('click');
+                    }
+                }
+                
+                // Warte bis alle Items erstellt sind, dann setze die Werte
+                setTimeout(function() {
+                    
+                    // Nochmal alle Felder durchgehen und Werte setzen
+                    $.each(parsedData, function(fieldName, fieldValue) {
+                        var newFieldName = fieldName;
+                        
+                        if (sourceUID && sourceUID.length > 0) {
+                            var pattern1 = new RegExp('\\[' + sourceUID.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\]', 'g');
+                            newFieldName = newFieldName.replace(pattern1, '[' + uID + ']');
+                            var pattern2 = new RegExp("\\['" + sourceUID.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + "'\\]", 'g');
+                            newFieldName = newFieldName.replace(pattern2, "['" + uID + "']");
+                        } else {
+                            newFieldName = fieldName.replace(/\[GBS[a-f0-9]{40}\]/g, '[' + uID + ']');
+                            newFieldName = newFieldName.replace(/\['GBS[a-f0-9]{40}'\]/g, "['" + uID + "']");
+                        }
+                        
+                        var targetField = dst.find('[name="' + newFieldName + '"]');
+                        if (targetField.length > 0) {
+                            if (targetField.is(':checkbox') || targetField.is(':radio')) {
+                                targetField.prop('checked', targetField.val() == fieldValue);
+                            } else {
+                                targetField.val(fieldValue);
+                            }
+                            targetField.trigger('change');
+                        }
+                    });
+                    
+                }, (neededItems - currentItems) * 150); // Warte basierend auf Anzahl neuer Items
+            }
+            
+            // MBlock neu initialisieren
+            self.reinitializeMBlock(mblockWrapper);
+        });
+    }
+};

--- a/boot.php
+++ b/boot.php
@@ -104,4 +104,5 @@ if ($a1620_darkmode) { rex_view::addCssFile($this->getAssetsUrl('style-darkmode.
 
 rex_view::addJsFile($this->getAssetsUrl('sortable.min.js?v=' . $this->getVersion()));
 rex_view::addJsFile($this->getAssetsUrl('script.js?v=' . $this->getVersion()));
+rex_view::addJsFile($this->getAssetsUrl('gridblock_mblock.js?v=' . $this->getVersion()));
 ?>

--- a/fragments/gridblock/module_input.php
+++ b/fragments/gridblock/module_input.php
@@ -350,10 +350,31 @@ $(function(){
 		
 		if (colID > 0 && uID != undefined) {
 			if (!$(this).hasClass(cClass)) {
+				// Vollständige Slice-Daten sammeln
+				var currentSlice = $(this).closest('.column-slice');
+				var allFormData = {};
+				
+				// Alle Formularfelder in diesem Slice sammeln (auch MBlock)
+				currentSlice.find('input, textarea, select').each(function() {
+					var fieldName = $(this).attr('name');
+					var fieldValue = '';
+					
+					if ($(this).is(':checkbox') || $(this).is(':radio')) {
+						if ($(this).is(':checked')) {
+							fieldValue = $(this).val();
+						}
+					} else {
+						fieldValue = $(this).val();
+					}
+					
+					if (fieldName && fieldValue !== undefined && fieldValue !== '') {
+						allFormData[fieldName] = fieldValue;
+					}
+				});
+				
 				//kopierten Block im Cookie zwischenspeichern
 				$.ajax({
-					url: 'index.php?page=structure&rex-api-call=gridblock_setCookie&sliceid=' +gridblock_sliceid+ '&uid=' +uID+ '&colid=' +colID+ '&modid=' +modID+ '&modstatus=' +modStatus+ '&action=copy&buster=<?php echo microtime(true); ?>',
-					success: function(data) {},
+					url: 'index.php?page=structure&rex-api-call=gridblock_setCookie&sliceid=' +gridblock_sliceid+ '&uid=' +uID+ '&colid=' +colID+ '&modid=' +modID+ '&modstatus=' +modStatus+ '&action=copy&form_data=' +encodeURIComponent(JSON.stringify(allFormData))+ '&source_uid=' +uID+ '&buster=<?php echo microtime(true); ?>',
 					async: false
 				});
 				
@@ -425,7 +446,72 @@ function gridblock_loadModule(moduleID, colID, uID, moduleName, action = "") {
 			dst.append(data).show();
 			
 			//kopierten Status setzen
-			if (action == 'copy' && gridblock_getCookie('action') == 'copy' && gridblock_getCookie('modstatus') != 1) { dst.find('.column-slice-sorter a.btn-status').trigger('click'); }
+			if (action == 'copy' && gridblock_getCookie('action') == 'copy' && gridblock_getCookie('modstatus') != 1) { 
+				dst.find('.column-slice-sorter a.btn-status').trigger('click'); 
+			}
+			
+			// MBlock-Daten und andere Formular-Daten wiederherstellen beim Kopieren
+			if (action == 'copy') {
+				
+				setTimeout(function() {
+					var formData = gridblock_getCookie('form_data');
+					var sourceUID = gridblock_getCookie('source_uid');
+					
+					if (formData && formData.length > 0) {
+						try {
+							var parsedData = JSON.parse(decodeURIComponent(formData));
+							
+							var fieldsSet = 0;
+							
+							// 1. Normale Formularfelder wiederherstellen
+							$.each(parsedData, function(fieldName, fieldValue) {
+								// Feldnamen für das neue uID anpassen
+								var newFieldName = fieldName;
+								
+								// Intelligentere UID-Ersetzung: nur die Gridblock-spezifischen UIDs ersetzen
+								// Beispiel: REX_INPUT_VALUE[1][GBSxxx][VALUE][1_MBLOCK][0][label]
+								//           REX_INPUT_VALUE[19][1]['GBSxxx'][id]
+								
+								if (sourceUID && sourceUID.length > 0) {
+									// Variante 1: [GBSxxx] → [neue_UID]
+									var pattern1 = new RegExp('\\[' + sourceUID.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\]', 'g');
+									newFieldName = newFieldName.replace(pattern1, '[' + uID + ']');
+									
+									// Variante 2: ['GBSxxx'] → ['neue_UID'] (für Arrays mit Anführungszeichen)
+									var pattern2 = new RegExp("\\['" + sourceUID.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + "'\\]", 'g');
+									newFieldName = newFieldName.replace(pattern2, "['" + uID + "']");
+								} else {
+									// Fallback: Versuche automatische UID-Erkennung
+									// Suche nach GBS-Pattern und ersetze diese
+									newFieldName = fieldName.replace(/\[GBS[a-f0-9]{40}\]/g, '[' + uID + ']');
+									newFieldName = newFieldName.replace(/\['GBS[a-f0-9]{40}'\]/g, "['" + uID + "']");
+								}
+								
+								// Feld finden und Wert setzen
+								var targetField = dst.find('[name="' + newFieldName + '"]');
+								if (targetField.length > 0) {
+									if (targetField.is(':checkbox') || targetField.is(':radio')) {
+										targetField.prop('checked', targetField.val() == fieldValue);
+									} else {
+										targetField.val(fieldValue);
+									}
+									targetField.trigger('change');
+									fieldsSet++;
+								}
+							});
+							
+							// 2. MBlock-spezifische Nachbearbeitung
+							if (typeof window.GridblockMBlock !== 'undefined') {
+								// MBlock-Daten mit der ausgelagerten Funktion wiederherstellen
+								window.GridblockMBlock.processMBlockData(dst, parsedData, sourceUID, uID);
+							}
+							
+						} catch (e) {
+							console.error('Fehler beim Wiederherstellen der Formulardaten:', e);
+						}
+					}
+				}, 800); // Längere Verzögerung für MBlock-Initialisierung
+			}
 			
 			//Vorgang mit ready abschließen
 			$('body').trigger('rex:ready', [$('body')]);					//macht Probleme -> setzt die Spalten-Navigation zurück

--- a/lib/gridblock_api.php
+++ b/lib/gridblock_api.php
@@ -93,9 +93,20 @@ class rex_api_gridblock_setCookie extends rex_api_function
 		$modID 		= rex_request::get('modid', 'int', null);
 		$modStatus	= rex_request::get('modstatus', 'int', null);
 		$action		= rex_request::get('action');
+		$formData   = rex_request::get('form_data', 'string', '');
+		$sourceUID  = rex_request::get('source_uid', 'string', '');
 		
 		if (!empty($uID) && !empty($action)):
-			$value = ['sliceid' => $sliceID, 'uid' => $uID, 'colid' => $colID, 'modid' => $modID, 'modstatus' => $modStatus, 'action' => $action];
+			$value = [
+				'sliceid' => $sliceID, 
+				'uid' => $uID, 
+				'colid' => $colID, 
+				'modid' => $modID, 
+				'modstatus' => $modStatus, 
+				'action' => $action,
+				'form_data' => $formData,
+				'source_uid' => $sourceUID
+			];
             rex_article_content_gridblock::setCookie($value);
 			exit();
         endif;


### PR DESCRIPTION
# MBlock Copy/Paste Support für Gridblock

## Problem
Gridblock konnte bisher keine Slices mit MBlock-Inhalten kopieren. MBlock-Daten und -Funktionalität gingen beim Copy/Paste verloren.

Moin!

- **Copy/Paste für MBlocks**: Vollständige Unterstützung für verschachtelte MBlock-Strukturen
- **Datenerhaltung**: Alle Formularwerte und MBlock-Items werden korrekt übertragen
- **Automatische Initialisierung**: Kopierte MBlocks funktionieren sofort (Add/Remove/Sort)
- **Smart UID-Mapping**: Intelligente Ersetzung von GBS-Hashes und UIDs

## Technisch
- **Neue JS-Datei**: `assets/gridblock_mblock.js` - Modulare MBlock-Integration
- **API erweitert**: `gridblock_api.php` mit `form_data` und `source_uid` Support
- **Sauberer Code**: MBlock-Logic ausgelagert, produktionstauglich

## Files
- `fragments/gridblock/module_input.php` - Copy/Paste UI + Integration
- `lib/gridblock_api.php` - Erweiterte Cookie-Behandlung
- `assets/gridblock_mblock.js` - MBlock-Kompatibilitätsschicht (neu)
- `boot.php` - Asset-Loading

Puh. War nicht einfach. Bitte testen. 
