### PR TITLE
Fix: rex:ready nur auf den neu geladenen Bereich triggern

### DIFF
--- a/fragments/gridblock/module_input.php
+++ b/fragments/gridblock/module_input.php
@@ -427,10 +427,10 @@ function gridblock_loadModule(moduleID, colID, uID, moduleName, action = "") {
 			//kopierten Status setzen
 			if (action == 'copy' && gridblock_getCookie('action') == 'copy' && gridblock_getCookie('modstatus') != 1) { dst.find('.column-slice-sorter a.btn-status').trigger('click'); }
 			
-			//Vorgang mit ready abschließen
-			$('body').trigger('rex:ready', [$('body')]);					//macht Probleme -> setzt die Spalten-Navigation zurück
-			$(document).trigger('ready');
-			$(document).trigger('pjax:success');
+			// Nur den neu geladenen Modulbereich initialisieren statt der ganzen Seite.
+			// Ein globaler $('body').trigger('rex:ready') setzt u.a. die Spalten-Navigation
+			// zurück und initialisiert fremde Widgets (z.B. Editoren) doppelt.
+			dst.trigger('rex:ready', [dst]);
 		}).always(function() {
 			$('#rex-js-ajax-loader').removeClass('rex-visible');
 		}).fail(function() {
@@ -588,9 +588,8 @@ function gridblock_loadContentSettings(templateID, colID = 0) {
 			dst.html(data);
 			gridblock_showHideContentSettings(data.length, templateID, colID);
 			
-			$('body').trigger('rex:ready', [$('body')]);					//macht Probleme -> setzt die Spalten-Navigation zurück
-			$(document).trigger('ready');
-			$(document).trigger('pjax:success');
+			// Nur den neu geladenen Bereich initialisieren statt der ganzen Seite.
+			dst.trigger('rex:ready', [dst]);
 		}).fail(function() {
 			dst.html('<div class="alert alert-danger"><?php echo rex_i18n::msg('a1620_mod_error_loadcontentoptions'); ?></div>');
 		})


### PR DESCRIPTION
## Problem

Beim dynamischen Nachladen von Modulen (`gridblock_loadModule`) und Content-Settings (`gridblock_loadContentSettings`) wurde bisher ein **globaler** Trigger ausgelöst:

```js
$('body').trigger('rex:ready', [$('body')]);   // macht Probleme -> setzt die Spalten-Navigation zurück
$(document).trigger('ready');
$(document).trigger('pjax:success');
```

Der Kommentar im Code wies bereits auf das Problem hin: Der globale `rex:ready` initialisiert die **gesamte Seite** neu. Das

- setzt die Spalten-Navigation zurück und
- initialisiert fremde Widgets (z. B. CKE5-/TinyMCE-Editoren) mehrfach bzw. fehlerhaft.

## Lösung

Statt der ganzen Seite wird nur der **neu geladene Zielbereich** initialisiert:

```js
dst.trigger('rex:ready', [dst]);
```

Das ist der idiomatische REDAXO-Weg: `rex:ready` mit Scope-Parameter initialisiert gezielt nur den übergebenen Container.

## Auswirkung

- Spalten-Navigation bleibt erhalten
- Editoren und andere Widgets werden nicht mehr doppelt initialisiert
- Betrifft beide AJAX-Done-Handler in `fragments/gridblock/module_input.php`